### PR TITLE
Modified getRealtimeInterestPoints endpoint to match new parameters for it

### DIFF
--- a/src/microservices/realtime/schema.graphql
+++ b/src/microservices/realtime/schema.graphql
@@ -21,7 +21,7 @@ type RealtimeInterestPoint {
 
 type Query {
   "Returns all interest points near to a specific point"
-  getRealtimeInterestPoints(id: Int!, radius: Float!): [RealtimeInterestPoint]
+  getRealtimeInterestPoints(lat: Float!, lng: Float!, radius: Float!): [RealtimeInterestPoint]
 }
 
 type Mutation {


### PR DESCRIPTION
New endpoint parameters require coordinates of center of search area, thus making redundant the usage of internal ids.